### PR TITLE
Add check if the "BitDepth" parameter is settable

### DIFF
--- a/src/Andor3Camera.cpp
+++ b/src/Andor3Camera.cpp
@@ -1360,6 +1360,14 @@ void
 lima::Andor3::Camera::setBitDepth(A3_BitDepth iMode)
 {
   DEB_MEMBER_FUNCT();
+  AT_BOOL readonly, writable;
+  AT_IsReadOnly(m_camera_handle, andor3::BitDepth, &readonly);
+  AT_IsWritable(m_camera_handle, andor3::BitDepth, &writable);
+  if (readonly || !writable)
+  {
+    DEB_ALWAYS() << "BitDepth is not settable";
+    return;
+  }
   int the_mode;
   setEnumIndex(andor3::BitDepth, static_cast<int>(iMode));
   getHwBitDepth(&the_mode);


### PR DESCRIPTION
The Andor Neo sCMOS camera seems to be (at least some examplar) not able to set the "BitDepth" parameter directly. Therefor a check is added, which gives some output about it an will return immediately.